### PR TITLE
[FEAT] 사용자 프로필 등록 기능

### DIFF
--- a/src/main/java/com/keodam/keodam_backend/app/domain/User.java
+++ b/src/main/java/com/keodam/keodam_backend/app/domain/User.java
@@ -92,6 +92,10 @@ public class User {
         this.nicknameChanged = true;
     }
 
+    public void updateProfileImage(String newProfileImage) {
+        this.profileUrl = newProfileImage;
+    }
+
     public void updateRole(RoleType roleType) {
         if (roleType != null) this.roleType = roleType;
     }

--- a/src/main/java/com/keodam/keodam_backend/app/domain/User.java
+++ b/src/main/java/com/keodam/keodam_backend/app/domain/User.java
@@ -1,5 +1,6 @@
 package com.keodam.keodam_backend.app.domain;
 
+import com.keodam.keodam_backend.app.user.domain.ProfileStatus;
 import com.keodam.keodam_backend.exception.GeneralException;
 import com.keodam.keodam_backend.global.code.status.ErrorStatus;
 import com.keodam.keodam_backend.mypage.domain.UserVerification;
@@ -65,6 +66,10 @@ public class User {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<UserVerification> verifications = new ArrayList<>();
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "profile_status")
+    private ProfileStatus profileStatus;
+
     @Builder
     public User(String nickname, String email, String profileUrl, SocialType socialType, RoleType roleType, String oauthId) {
         this.nickname = nickname;
@@ -94,6 +99,7 @@ public class User {
 
     public void updateProfileImage(String newProfileImage) {
         this.profileUrl = newProfileImage;
+        this.profileStatus = ProfileStatus.PENDING;
     }
 
     public void updateRole(RoleType roleType) {

--- a/src/main/java/com/keodam/keodam_backend/app/user/controller/UserController.java
+++ b/src/main/java/com/keodam/keodam_backend/app/user/controller/UserController.java
@@ -8,6 +8,8 @@ import com.keodam.keodam_backend.app.user.service.UserService;
 import com.keodam.keodam_backend.exception.GeneralException;
 import com.keodam.keodam_backend.global.ApiResponse;
 import com.keodam.keodam_backend.global.code.status.ErrorStatus;
+import com.keodam.keodam_backend.mypage.dto.request.FileRequestDto;
+import com.keodam.keodam_backend.mypage.dto.response.FileResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -15,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/user")
@@ -40,7 +43,7 @@ public class UserController {
     }
 
     @GetMapping("/nickname/check")
-    @Operation(summary = "닉네임 중복 확인", description = "닉네임 검증 API",security = @SecurityRequirement(name = "Authorization"))
+    @Operation(summary = "닉네임 중복 확인", description = "닉네임 검증 API", security = @SecurityRequirement(name = "Authorization"))
     public ResponseEntity<ApiResponse<String>> checkNickname(@RequestParam String nickname) {
         userService.validateNickname(nickname);
         return ResponseEntity.ok(ApiResponse.onSuccess("사용 가능한 닉네임입니다."));
@@ -59,5 +62,16 @@ public class UserController {
         UserResponseDto updatedUser = userService.updateRole(user, roleRequestDto.roleType());
 
         return ResponseEntity.ok(ApiResponse.onSuccess(updatedUser));
+    }
+
+    @PostMapping(value = "file", consumes = "multipart/form-data")
+    @Operation(summary = "사용자 프로필 사진 등록", description = "파일이미지로 프로필 등록 API", security = @SecurityRequirement(name = "Authorization"))
+    public ResponseEntity<ApiResponse<UserResponseDto>> uploadProfileImage(Authentication authentication,
+                                                             @RequestPart(name = "ImageFile", required = true) MultipartFile file) {
+        String email = authentication.getName();
+        User user = userService.findByEmail(email)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        return ResponseEntity.ok(ApiResponse.onSuccess(userService.uploadProfileImage(user, file)));
     }
 }

--- a/src/main/java/com/keodam/keodam_backend/app/user/controller/UserController.java
+++ b/src/main/java/com/keodam/keodam_backend/app/user/controller/UserController.java
@@ -64,8 +64,8 @@ public class UserController {
         return ResponseEntity.ok(ApiResponse.onSuccess(updatedUser));
     }
 
-    @PostMapping(value = "file", consumes = "multipart/form-data")
-    @Operation(summary = "사용자 프로필 사진 등록", description = "파일이미지로 프로필 등록 API", security = @SecurityRequirement(name = "Authorization"))
+    @PatchMapping(value = "file", consumes = "multipart/form-data")
+    @Operation(summary = "사용자 프로필 사진 등록 및 수정", description = "파일이미지로 프로필 등록 API", security = @SecurityRequirement(name = "Authorization"))
     public ResponseEntity<ApiResponse<UserResponseDto>> uploadProfileImage(Authentication authentication,
                                                              @RequestPart(name = "ImageFile", required = true) MultipartFile file) {
         String email = authentication.getName();

--- a/src/main/java/com/keodam/keodam_backend/app/user/domain/ProfileStatus.java
+++ b/src/main/java/com/keodam/keodam_backend/app/user/domain/ProfileStatus.java
@@ -1,0 +1,7 @@
+package com.keodam.keodam_backend.app.user.domain;
+
+public enum ProfileStatus {
+    PENDING,
+    APPROVED,
+    REJECTED
+}

--- a/src/main/java/com/keodam/keodam_backend/app/user/service/UserService.java
+++ b/src/main/java/com/keodam/keodam_backend/app/user/service/UserService.java
@@ -5,10 +5,12 @@ import com.keodam.keodam_backend.app.domain.User;
 import com.keodam.keodam_backend.app.user.repository.UserRepository;
 import com.keodam.keodam_backend.app.user.dto.UserResponseDto;
 import com.keodam.keodam_backend.exception.GeneralException;
+import com.keodam.keodam_backend.global.aws.AwsS3Service;
 import com.keodam.keodam_backend.global.code.status.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Optional;
 
@@ -18,6 +20,7 @@ public class UserService {
 
     private final BannedWordsService bannedWordsService;
     private final UserRepository userRepository;
+    private final AwsS3Service awsS3Service;
 
     /**
      * 닉네임 저장 및 중복 체크
@@ -51,14 +54,17 @@ public class UserService {
                 .profileUrl(user.getProfileUrl())
                 .roleType(user.getRoleType())
                 .hasProfileImage(user.getProfileUrl() != null)
-                .hasRole(user.getRoleType() != null && user.getRoleType()!=RoleType.GUEST)
+                .hasRole(user.getRoleType() != null && user.getRoleType() != RoleType.GUEST)
                 .build();
+    }
+
+    public void uploadProfileImage(User user, MultipartFile file) {
+        String imgUrl = awsS3Service.uploadFile(file);
     }
 
     public Optional<User> findByEmail(String email) {
         return userRepository.findByEmail(email);
     }
-
 
     private boolean containsSpecialChar(String nickname) {
         // 한글, 영어, 숫자만 허용. 그 외는 특수문자

--- a/src/main/java/com/keodam/keodam_backend/app/user/service/UserService.java
+++ b/src/main/java/com/keodam/keodam_backend/app/user/service/UserService.java
@@ -58,8 +58,21 @@ public class UserService {
                 .build();
     }
 
-    public void uploadProfileImage(User user, MultipartFile file) {
+    public UserResponseDto uploadProfileImage(User user, MultipartFile file) {
         String imgUrl = awsS3Service.uploadFile(file);
+
+        if (user.getProfileUrl() != null) {
+            awsS3Service.deleteFile(user.getProfileUrl());
+        }
+        user.updateProfileImage(imgUrl);
+        userRepository.save(user);
+
+        return UserResponseDto.builder()
+                .id(user.getId())
+                .nickname(user.getNickname())
+                .roleType(user.getRoleType())
+                .profileUrl(user.getProfileUrl())
+                .build();
     }
 
     public Optional<User> findByEmail(String email) {


### PR DESCRIPTION
## 사용자 프로필 등록/수정 기능 구현

### 📌 작업 내용
- 사용자 프로필 이미지 등록 및 수정 기능 추가
  - `PATCH /users/file` API 구현
  - S3에 이미지 업로드 후 기존 이미지가 있을 경우 삭제
  - 업로드한 이미지 URL을 사용자 정보에 저장 (`profileUrl`)
- 프로필 상태 (`profileStatus`)는 추후 관리자 승인/거부 기능 개발 시 작업 예정( 현재는 `PENDING`으로 기본 값입니다)