### PR TITLE
Feat/#37 : 추천인 등록 및 보상 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ out/
 **/*.properties
 !gradle/wrapper/gradle-wrapper.properties
 src/main/resources/application.yml
+/src/main/resources/

--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     //json
     implementation 'org.json:json:20210307'
+    implementation 'io.netty:netty-resolver-dns-native-macos:4.1.68.Final:osx-aarch_64'
 }
 
 

--- a/src/main/java/com/keodam/keodam_backend/app/phone/controller/UserAuthenticateController.java
+++ b/src/main/java/com/keodam/keodam_backend/app/phone/controller/UserAuthenticateController.java
@@ -25,7 +25,7 @@ public class UserAuthenticateController {
     @PostMapping("/code")
     @Operation(summary = "인증번호 요청", description = "사용자 정보 기반 인증요청 API", security = @SecurityRequirement(name = "Authorization"))
     public ResponseEntity<Object> requestVerifyCode(Authentication authentication, @RequestBody UserVerifyCodeRequestDto dto) {
-        String email = authentication.getName(); // 여기서 이메일 추출
+        String email = authentication.getName();
         return userAuthenticateService.startVerification(dto, email);
     }
 

--- a/src/main/java/com/keodam/keodam_backend/app/user/referral/controller/ReferralController.java
+++ b/src/main/java/com/keodam/keodam_backend/app/user/referral/controller/ReferralController.java
@@ -4,8 +4,10 @@ import com.keodam.keodam_backend.app.domain.User;
 import com.keodam.keodam_backend.app.user.referral.dto.ReferralRequestDto;
 import com.keodam.keodam_backend.app.user.referral.service.ReferralService;
 import com.keodam.keodam_backend.app.user.service.UserService;
+import com.keodam.keodam_backend.exception.GeneralException;
 import com.keodam.keodam_backend.global.ApiResponse;
 import com.keodam.keodam_backend.global.code.status.ErrorStatus;
+import com.keodam.keodam_backend.global.code.status.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -25,7 +27,7 @@ public class ReferralController {
 
     @PostMapping("/referral")
     @Operation(summary = "추천인 등록", description = "추천인 등록 API", security = @SecurityRequirement(name = "Authorization"))
-    public ResponseEntity<?> registerReferral(
+    public ResponseEntity<ApiResponse<String>> registerReferral(
             @RequestBody ReferralRequestDto referralRequestDto,
             Authentication authentication) {
 
@@ -39,17 +41,12 @@ public class ReferralController {
         }
 
         String email = authentication.getName();
-        User sponsor = userService.findByEmail(email).orElse(null);
+        User sponsor = userService.findByEmail(email)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
-        if (sponsor == null) {
-            return ResponseEntity.status(ErrorStatus.USER_NOT_FOUND.getHttpStatus())
-                    .body(ApiResponse.onFailure(
-                            ErrorStatus.USER_NOT_FOUND.getCode(),
-                            ErrorStatus.USER_NOT_FOUND.getMessage(),
-                            null
-                    ));
-        }
+        String message = referralService.registerReferral(sponsor, referralRequestDto.getRefereeNickname());
 
-        return referralService.registerReferral(sponsor, referralRequestDto.getRefereeNickname());
+        return ResponseEntity.status(SuccessStatus._OK.getHttpStatus())
+                .body(ApiResponse.of(SuccessStatus._OK, message));
     }
 }

--- a/src/main/java/com/keodam/keodam_backend/app/user/referral/controller/ReferralController.java
+++ b/src/main/java/com/keodam/keodam_backend/app/user/referral/controller/ReferralController.java
@@ -4,8 +4,6 @@ import com.keodam.keodam_backend.app.domain.User;
 import com.keodam.keodam_backend.app.user.referral.dto.ReferralRequestDto;
 import com.keodam.keodam_backend.app.user.referral.service.ReferralService;
 import com.keodam.keodam_backend.app.user.service.UserService;
-import com.keodam.keodam_backend.exception.GeneralException;
-import com.keodam.keodam_backend.global.ApiResponse;
 import com.keodam.keodam_backend.global.code.status.ErrorStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -13,12 +11,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
-@Controller
+@RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/user")
 @Tag(name = "User", description = "User API")
@@ -29,15 +24,20 @@ public class ReferralController {
 
     @PostMapping("/referral")
     @Operation(summary = "추천인 등록", description = "추천인 등록 API", security = @SecurityRequirement(name = "Authorization"))
-    public ResponseEntity<ApiResponse<String>> registerReferral(
+    public ResponseEntity<?> registerReferral(
             @RequestBody ReferralRequestDto referralRequestDto,
             Authentication authentication) {
 
         String email = authentication.getName();
-        User sponser = userService.findByEmail(email)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
-        referralService.registerReferral(sponser, referralRequestDto.getRefereeNickname());
 
-        return ResponseEntity.ok(ApiResponse.onSuccess("추천인 등록 완료"));
+        User sponsor = userService.findByEmail(email)
+                .orElse(null);
+
+        if (sponsor == null) {
+            return ResponseEntity.status(ErrorStatus.USER_NOT_FOUND.getHttpStatus())
+                    .body(ErrorStatus.USER_NOT_FOUND.getReasonHttpStatus());
+        }
+
+        return referralService.registerReferral(sponsor, referralRequestDto.getRefereeNickname());
     }
 }

--- a/src/main/java/com/keodam/keodam_backend/app/user/referral/controller/ReferralController.java
+++ b/src/main/java/com/keodam/keodam_backend/app/user/referral/controller/ReferralController.java
@@ -1,24 +1,43 @@
 package com.keodam.keodam_backend.app.user.referral.controller;
 
+import com.keodam.keodam_backend.app.domain.User;
 import com.keodam.keodam_backend.app.user.referral.dto.ReferralRequestDto;
 import com.keodam.keodam_backend.app.user.referral.service.ReferralService;
+import com.keodam.keodam_backend.app.user.service.UserService;
+import com.keodam.keodam_backend.exception.GeneralException;
+import com.keodam.keodam_backend.global.ApiResponse;
+import com.keodam.keodam_backend.global.code.status.ErrorStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
-@RequestMapping("/api/user/referral")
 @RequiredArgsConstructor
+@RequestMapping("/api/user")
+@Tag(name = "User", description = "User API")
 public class ReferralController {
 
     private final ReferralService referralService;
+    private final UserService userService;
 
-    @PostMapping
-    public ResponseEntity<String> registerReferral(@RequestBody ReferralRequestDto dto){
-        referralService.registerReferral(dto.getInviteeId(), dto.getReferrerNickname());
-        return ResponseEntity.ok("추천인 등록 및 보상 지급 완료.");
+    @PostMapping("/referral")
+    @Operation(summary = "추천인 등록", description = "추천인 등록 API", security = @SecurityRequirement(name = "Authorization"))
+    public ResponseEntity<ApiResponse<String>> registerReferral(
+            @RequestBody ReferralRequestDto referralRequestDto,
+            Authentication authentication) {
+
+        String email = authentication.getName();
+        User sponser = userService.findByEmail(email)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+        referralService.registerReferral(sponser, referralRequestDto.getRefereeNickname());
+
+        return ResponseEntity.ok(ApiResponse.onSuccess("추천인 등록 완료"));
     }
 }

--- a/src/main/java/com/keodam/keodam_backend/app/user/referral/controller/ReferralController.java
+++ b/src/main/java/com/keodam/keodam_backend/app/user/referral/controller/ReferralController.java
@@ -1,0 +1,24 @@
+package com.keodam.keodam_backend.app.user.referral.controller;
+
+import com.keodam.keodam_backend.app.user.referral.dto.ReferralRequestDto;
+import com.keodam.keodam_backend.app.user.referral.service.ReferralService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/api/user/referral")
+@RequiredArgsConstructor
+public class ReferralController {
+
+    private final ReferralService referralService;
+
+    @PostMapping
+    public ResponseEntity<String> registerReferral(@RequestBody ReferralRequestDto dto){
+        referralService.registerReferral(dto.getInviteeId(), dto.getReferrerNickname());
+        return ResponseEntity.ok("추천인 등록 및 보상 지급 완료.");
+    }
+}

--- a/src/main/java/com/keodam/keodam_backend/app/user/referral/controller/ReferralController.java
+++ b/src/main/java/com/keodam/keodam_backend/app/user/referral/controller/ReferralController.java
@@ -4,6 +4,7 @@ import com.keodam.keodam_backend.app.domain.User;
 import com.keodam.keodam_backend.app.user.referral.dto.ReferralRequestDto;
 import com.keodam.keodam_backend.app.user.referral.service.ReferralService;
 import com.keodam.keodam_backend.app.user.service.UserService;
+import com.keodam.keodam_backend.global.ApiResponse;
 import com.keodam.keodam_backend.global.code.status.ErrorStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -28,14 +29,25 @@ public class ReferralController {
             @RequestBody ReferralRequestDto referralRequestDto,
             Authentication authentication) {
 
-        String email = authentication.getName();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return ResponseEntity.status(ErrorStatus.UNAUTHORIZED.getHttpStatus())
+                    .body(ApiResponse.onFailure(
+                            ErrorStatus.UNAUTHORIZED.getCode(),
+                            ErrorStatus.UNAUTHORIZED.getMessage(),
+                            null
+                    ));
+        }
 
-        User sponsor = userService.findByEmail(email)
-                .orElse(null);
+        String email = authentication.getName();
+        User sponsor = userService.findByEmail(email).orElse(null);
 
         if (sponsor == null) {
             return ResponseEntity.status(ErrorStatus.USER_NOT_FOUND.getHttpStatus())
-                    .body(ErrorStatus.USER_NOT_FOUND.getReasonHttpStatus());
+                    .body(ApiResponse.onFailure(
+                            ErrorStatus.USER_NOT_FOUND.getCode(),
+                            ErrorStatus.USER_NOT_FOUND.getMessage(),
+                            null
+                    ));
         }
 
         return referralService.registerReferral(sponsor, referralRequestDto.getRefereeNickname());

--- a/src/main/java/com/keodam/keodam_backend/app/user/referral/domain/Referral.java
+++ b/src/main/java/com/keodam/keodam_backend/app/user/referral/domain/Referral.java
@@ -1,0 +1,44 @@
+package com.keodam.keodam_backend.app.user.referral.domain;
+
+import com.keodam.keodam_backend.app.domain.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+
+@Entity
+@Table(name = "referral")
+@Getter
+@NoArgsConstructor
+public class Referral {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne
+    @JoinColumn(name = "invitee_id")
+    private User invitee;
+
+    @ManyToOne
+    @JoinColumn(name = "referrer_id")
+    private User referrer;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @Builder
+    public Referral(User invitee, User referrer) {
+        this.invitee = invitee;
+        this.referrer = referrer;
+    }
+}

--- a/src/main/java/com/keodam/keodam_backend/app/user/referral/domain/Referral.java
+++ b/src/main/java/com/keodam/keodam_backend/app/user/referral/domain/Referral.java
@@ -2,6 +2,7 @@ package com.keodam.keodam_backend.app.user.referral.domain;
 
 import com.keodam.keodam_backend.app.domain.User;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -14,11 +15,13 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Table(name = "referral")
 @Getter
 @NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
 public class Referral {
 
     @Id
@@ -26,19 +29,19 @@ public class Referral {
     private Long id;
 
     @OneToOne
-    @JoinColumn(name = "invitee_id")
-    private User invitee;
+    @JoinColumn(name = "sponsor_id")
+    private User sponsor;
 
     @ManyToOne
-    @JoinColumn(name = "referrer_id")
-    private User referrer;
+    @JoinColumn(name = "referee_id")
+    private User referee;
 
     @CreatedDate
     private LocalDateTime createdAt;
 
     @Builder
-    public Referral(User invitee, User referrer) {
-        this.invitee = invitee;
-        this.referrer = referrer;
+    public Referral(User sponsor, User referee) {
+        this.sponsor = sponsor;
+        this.referee = referee;
     }
 }

--- a/src/main/java/com/keodam/keodam_backend/app/user/referral/dto/ReferralRequestDto.java
+++ b/src/main/java/com/keodam/keodam_backend/app/user/referral/dto/ReferralRequestDto.java
@@ -1,0 +1,9 @@
+package com.keodam.keodam_backend.app.user.referral.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ReferralRequestDto {
+    private Long inviteeId;
+    private String referrerNickname;
+}

--- a/src/main/java/com/keodam/keodam_backend/app/user/referral/dto/ReferralRequestDto.java
+++ b/src/main/java/com/keodam/keodam_backend/app/user/referral/dto/ReferralRequestDto.java
@@ -4,6 +4,5 @@ import lombok.Getter;
 
 @Getter
 public class ReferralRequestDto {
-    private Long inviteeId;
-    private String referrerNickname;
+    private String refereeNickname;
 }

--- a/src/main/java/com/keodam/keodam_backend/app/user/referral/repository/ReferralRepository.java
+++ b/src/main/java/com/keodam/keodam_backend/app/user/referral/repository/ReferralRepository.java
@@ -6,5 +6,5 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReferralRepository extends JpaRepository<Referral, Long> {
-    Optional<Referral> findByReferrer(User referrer);
+    Optional<Referral> findBySponsor(User referrer);
 }

--- a/src/main/java/com/keodam/keodam_backend/app/user/referral/repository/ReferralRepository.java
+++ b/src/main/java/com/keodam/keodam_backend/app/user/referral/repository/ReferralRepository.java
@@ -1,0 +1,10 @@
+package com.keodam.keodam_backend.app.user.referral.repository;
+
+import com.keodam.keodam_backend.app.domain.User;
+import com.keodam.keodam_backend.app.user.referral.domain.Referral;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReferralRepository extends JpaRepository<Referral, Long> {
+    Optional<Referral> findByReferrer(User referrer);
+}

--- a/src/main/java/com/keodam/keodam_backend/app/user/referral/service/ReferralService.java
+++ b/src/main/java/com/keodam/keodam_backend/app/user/referral/service/ReferralService.java
@@ -4,11 +4,10 @@ import com.keodam.keodam_backend.app.domain.User;
 import com.keodam.keodam_backend.app.user.referral.domain.Referral;
 import com.keodam.keodam_backend.app.user.referral.repository.ReferralRepository;
 import com.keodam.keodam_backend.app.user.repository.UserRepository;
+import com.keodam.keodam_backend.exception.GeneralException;
 import com.keodam.keodam_backend.global.code.status.ErrorStatus;
-import com.keodam.keodam_backend.global.code.status.SuccessStatus;
 import com.keodam.keodam_backend.mypage.payment.service.BeanWalletService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -19,23 +18,17 @@ public class ReferralService {
     private final ReferralRepository referralRepository;
     private final BeanWalletService beanWalletService;
 
-    public ResponseEntity<Object> registerReferral(User sponsor, String refereeNickname) {
+    public String registerReferral(User sponsor, String refereeNickname) {
+
         if (referralRepository.findBySponsor(sponsor).isPresent()) {
-            return ResponseEntity.status(ErrorStatus.ALREADY_REGISTER_REFERRAL.getHttpStatus())
-                    .body(ErrorStatus.ALREADY_REGISTER_REFERRAL.getReasonHttpStatus());
+            throw new GeneralException(ErrorStatus.ALREADY_REGISTER_REFERRAL);
         }
 
         User referee = userRepository.findByNickname(refereeNickname)
-                .orElse(null);
-
-        if (referee == null) {
-            return ResponseEntity.status(ErrorStatus.USER_NOT_FOUND.getHttpStatus())
-                    .body(ErrorStatus.USER_NOT_FOUND.getReasonHttpStatus());
-        }
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
         if (sponsor.getId().equals(referee.getId())) {
-            return ResponseEntity.status(ErrorStatus.CANNOT_REFER_SELF.getHttpStatus())
-                    .body(ErrorStatus.CANNOT_REFER_SELF.getReasonHttpStatus());
+            throw new GeneralException(ErrorStatus.CANNOT_REFER_SELF);
         }
 
         Referral referral = Referral.builder()
@@ -48,11 +41,8 @@ public class ReferralService {
             beanWalletService.rewardReferralBeans(sponsor, 100);
             beanWalletService.rewardReferralBeans(referee, 100);
         } catch (Exception e) {
-            return ResponseEntity.status(ErrorStatus.INTERNAL_SERVER_ERROR.getHttpStatus())
-                    .body(ErrorStatus.INTERNAL_SERVER_ERROR.getReasonHttpStatus());
+            throw new GeneralException(ErrorStatus.INTERNAL_SERVER_ERROR);
         }
-
-        return ResponseEntity.status(SuccessStatus._OK.getHttpStatus())
-                .body(SuccessStatus._OK.getReasonHttpStatus());
+        return "추천이 성공적으로 등록되었습니다.";
     }
 }

--- a/src/main/java/com/keodam/keodam_backend/app/user/referral/service/ReferralService.java
+++ b/src/main/java/com/keodam/keodam_backend/app/user/referral/service/ReferralService.java
@@ -18,29 +18,26 @@ public class ReferralService {
     private final ReferralRepository referralRepository;
     private final BeanWalletService beanWalletService;
 
-    public void registerReferral(Long inviteeId, String referrerNickname){
-        User invitee = userRepository.findById(inviteeId).orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
-
-        if (referralRepository.findByReferrer(invitee).isPresent()){
+    public void registerReferral(User sponsor, String refereeNickname) {
+        if (referralRepository.findBySponsor(sponsor).isPresent()) {
             throw new GeneralException(ErrorStatus.ALREADY_REGISTER_REFERRAL);
         }
 
-        User referrer = userRepository.findByNickname(referrerNickname)
+        User referee = userRepository.findByNickname(refereeNickname)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
-        if (invitee.getId().equals(referrer.getId())){
+        if (sponsor.getId().equals(referee.getId())) {
             throw new GeneralException(ErrorStatus.CANNOT_REFER_SELF);
         }
 
         Referral referral = Referral.builder()
-                .invitee(invitee)
-                .referrer(referrer)
+                .sponsor(sponsor)
+                .referee(referee)
                 .build();
 
         referralRepository.save(referral);
 
-
-        beanWalletService.rewardReferralBeans(invitee, 100);
-        beanWalletService.rewardReferralBeans(referrer, 100);
+        beanWalletService.rewardReferralBeans(sponsor, 100);
+        beanWalletService.rewardReferralBeans(referee, 100);
     }
 }

--- a/src/main/java/com/keodam/keodam_backend/app/user/referral/service/ReferralService.java
+++ b/src/main/java/com/keodam/keodam_backend/app/user/referral/service/ReferralService.java
@@ -1,0 +1,46 @@
+package com.keodam.keodam_backend.app.user.referral.service;
+
+import com.keodam.keodam_backend.app.domain.User;
+import com.keodam.keodam_backend.app.user.referral.domain.Referral;
+import com.keodam.keodam_backend.app.user.referral.repository.ReferralRepository;
+import com.keodam.keodam_backend.app.user.repository.UserRepository;
+import com.keodam.keodam_backend.exception.GeneralException;
+import com.keodam.keodam_backend.global.code.status.ErrorStatus;
+import com.keodam.keodam_backend.mypage.payment.service.BeanWalletService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReferralService {
+
+    private final UserRepository userRepository;
+    private final ReferralRepository referralRepository;
+    private final BeanWalletService beanWalletService;
+
+    public void registerReferral(Long inviteeId, String referrerNickname){
+        User invitee = userRepository.findById(inviteeId).orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        if (referralRepository.findByReferrer(invitee).isPresent()){
+            throw new GeneralException(ErrorStatus.ALREADY_REGISTER_REFERRAL);
+        }
+
+        User referrer = userRepository.findByNickname(referrerNickname)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        if (invitee.getId().equals(referrer.getId())){
+            throw new GeneralException(ErrorStatus.CANNOT_REFER_SELF);
+        }
+
+        Referral referral = Referral.builder()
+                .invitee(invitee)
+                .referrer(referrer)
+                .build();
+
+        referralRepository.save(referral);
+
+
+        beanWalletService.rewardReferralBeans(invitee, 100);
+        beanWalletService.rewardReferralBeans(referrer, 100);
+    }
+}

--- a/src/main/java/com/keodam/keodam_backend/app/user/referral/service/ReferralService.java
+++ b/src/main/java/com/keodam/keodam_backend/app/user/referral/service/ReferralService.java
@@ -4,10 +4,11 @@ import com.keodam.keodam_backend.app.domain.User;
 import com.keodam.keodam_backend.app.user.referral.domain.Referral;
 import com.keodam.keodam_backend.app.user.referral.repository.ReferralRepository;
 import com.keodam.keodam_backend.app.user.repository.UserRepository;
-import com.keodam.keodam_backend.exception.GeneralException;
 import com.keodam.keodam_backend.global.code.status.ErrorStatus;
+import com.keodam.keodam_backend.global.code.status.SuccessStatus;
 import com.keodam.keodam_backend.mypage.payment.service.BeanWalletService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -18,26 +19,40 @@ public class ReferralService {
     private final ReferralRepository referralRepository;
     private final BeanWalletService beanWalletService;
 
-    public void registerReferral(User sponsor, String refereeNickname) {
+    public ResponseEntity<Object> registerReferral(User sponsor, String refereeNickname) {
         if (referralRepository.findBySponsor(sponsor).isPresent()) {
-            throw new GeneralException(ErrorStatus.ALREADY_REGISTER_REFERRAL);
+            return ResponseEntity.status(ErrorStatus.ALREADY_REGISTER_REFERRAL.getHttpStatus())
+                    .body(ErrorStatus.ALREADY_REGISTER_REFERRAL.getReasonHttpStatus());
         }
 
         User referee = userRepository.findByNickname(refereeNickname)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+                .orElse(null);
+
+        if (referee == null) {
+            return ResponseEntity.status(ErrorStatus.USER_NOT_FOUND.getHttpStatus())
+                    .body(ErrorStatus.USER_NOT_FOUND.getReasonHttpStatus());
+        }
 
         if (sponsor.getId().equals(referee.getId())) {
-            throw new GeneralException(ErrorStatus.CANNOT_REFER_SELF);
+            return ResponseEntity.status(ErrorStatus.CANNOT_REFER_SELF.getHttpStatus())
+                    .body(ErrorStatus.CANNOT_REFER_SELF.getReasonHttpStatus());
         }
 
         Referral referral = Referral.builder()
                 .sponsor(sponsor)
                 .referee(referee)
                 .build();
-
         referralRepository.save(referral);
 
-        beanWalletService.rewardReferralBeans(sponsor, 100);
-        beanWalletService.rewardReferralBeans(referee, 100);
+        try {
+            beanWalletService.rewardReferralBeans(sponsor, 100);
+            beanWalletService.rewardReferralBeans(referee, 100);
+        } catch (Exception e) {
+            return ResponseEntity.status(ErrorStatus.INTERNAL_SERVER_ERROR.getHttpStatus())
+                    .body(ErrorStatus.INTERNAL_SERVER_ERROR.getReasonHttpStatus());
+        }
+
+        return ResponseEntity.status(SuccessStatus._OK.getHttpStatus())
+                .body(SuccessStatus._OK.getReasonHttpStatus());
     }
 }

--- a/src/main/java/com/keodam/keodam_backend/app/user/repository/UserRepository.java
+++ b/src/main/java/com/keodam/keodam_backend/app/user/repository/UserRepository.java
@@ -13,4 +13,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Boolean existsByNickname(String nickname);
 
     Optional<User> findByOauthId(String oAuthId);
+
+    Optional<User> findByNickname(String nickname);
 }

--- a/src/main/java/com/keodam/keodam_backend/global/code/status/ErrorStatus.java
+++ b/src/main/java/com/keodam/keodam_backend/global/code/status/ErrorStatus.java
@@ -43,6 +43,8 @@ public enum ErrorStatus implements BaseErrorCode {
     //user
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER4001", "회원 정보를 찾을 수 없습니다."),
     FAMILY_ALREADY(HttpStatus.BAD_REQUEST, "FAMILY4002", "이미 가입한 가족이 존재합니다."),
+    ALREADY_REGISTER_REFERRAL(HttpStatus.BAD_REQUEST, "USER4003", "이미 추천인을 등록하셨습니다."),
+    CANNOT_REFER_SELF(HttpStatus.BAD_REQUEST, "USER4004", "자기 자신은 추천인으로 등록할 수 없습니다."),
 
     // nickname
     NICKNAME_SPECIAL_CHAR(HttpStatus.BAD_REQUEST, "NICKNAME4001", "특수문자는 닉네임에 포함될 수 없어요."),
@@ -57,7 +59,6 @@ public enum ErrorStatus implements BaseErrorCode {
 
     //document
     INVALID_DOCUMENT_TYPE(HttpStatus.BAD_REQUEST, "S34002", "유효하지 않은 문서 타입입니다."),
-
 
     // role type
     INVALID_ROLE_TYPE(HttpStatus.BAD_REQUEST, "ROLE4001", "잘못된 역할 선택입니다."),

--- a/src/main/java/com/keodam/keodam_backend/mypage/payment/domain/BeanTransaction.java
+++ b/src/main/java/com/keodam/keodam_backend/mypage/payment/domain/BeanTransaction.java
@@ -45,11 +45,12 @@ public class BeanTransaction {
     private BeanWallet wallet;
 
     @Builder
-    public BeanTransaction(User user, Payment payment, Payout payout, BeanTransactionType type, int beanAmount) {
+    public BeanTransaction(User user, Payment payment, Payout payout, BeanTransactionType type, int beanAmount, BeanWallet wallet) {
         this.user = user;
         this.payment = payment;
         this.payout = payout;
         this.type = type;
         this.beanAmount = beanAmount;
+        this.wallet = wallet;
     }
 }

--- a/src/main/java/com/keodam/keodam_backend/mypage/payment/domain/BeanTransactionType.java
+++ b/src/main/java/com/keodam/keodam_backend/mypage/payment/domain/BeanTransactionType.java
@@ -5,5 +5,6 @@ public enum BeanTransactionType {
     USE,
     REFUND,
     PROMOTION,
-    PAYOUT
+    PAYOUT,
+    REFERRAL_REWARD
 }

--- a/src/main/java/com/keodam/keodam_backend/mypage/payment/domain/BeanWallet.java
+++ b/src/main/java/com/keodam/keodam_backend/mypage/payment/domain/BeanWallet.java
@@ -19,6 +19,8 @@ public class BeanWallet {
     private Long id;
 
     private int totalBeans; //현재 보유 원두
+    @Column(name = "bean_amount_referral", nullable = false)
+    private int beanAmountReferral = 0;
 
     @OneToOne
     @JoinColumn(name = "user_id")
@@ -33,6 +35,18 @@ public class BeanWallet {
 
     public void decrease(int amount) {
         this.totalBeans -= amount;
+    }
+
+    public void increaseReferral(int amount) {
+        this.beanAmountReferral += amount;
+    }
+
+    public boolean canUseReferralBeans(int amount){
+        return this.beanAmountReferral >= amount;
+    }
+
+    public void decreaseReferral(int amount) {
+        this.beanAmountReferral -= amount;
     }
 
     @Builder

--- a/src/main/java/com/keodam/keodam_backend/mypage/payment/domain/BeanWallet.java
+++ b/src/main/java/com/keodam/keodam_backend/mypage/payment/domain/BeanWallet.java
@@ -18,7 +18,8 @@ public class BeanWallet {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private int totalBeans; //현재 보유 원두
+    private int totalBeans;
+
     @Column(name = "bean_amount_referral", nullable = false)
     private int beanAmountReferral = 0;
 

--- a/src/main/java/com/keodam/keodam_backend/mypage/payment/repository/BeanTransactionRepository.java
+++ b/src/main/java/com/keodam/keodam_backend/mypage/payment/repository/BeanTransactionRepository.java
@@ -3,5 +3,5 @@ package com.keodam.keodam_backend.mypage.payment.repository;
 import com.keodam.keodam_backend.mypage.payment.domain.BeanTransaction;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface beanTransactionRepository extends JpaRepository<BeanTransaction, Long> {
+public interface BeanTransactionRepository extends JpaRepository<BeanTransaction, Long> {
 }

--- a/src/main/java/com/keodam/keodam_backend/mypage/payment/repository/BeanWalletRepository.java
+++ b/src/main/java/com/keodam/keodam_backend/mypage/payment/repository/BeanWalletRepository.java
@@ -5,6 +5,6 @@ import com.keodam.keodam_backend.mypage.payment.domain.BeanWallet;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
-public interface beanWalletRepository extends JpaRepository<BeanWallet, Long> {
+public interface BeanWalletRepository extends JpaRepository<BeanWallet, Long> {
     Optional<BeanWallet> findByUser(User user);
 }

--- a/src/main/java/com/keodam/keodam_backend/mypage/payment/service/BeanWalletService.java
+++ b/src/main/java/com/keodam/keodam_backend/mypage/payment/service/BeanWalletService.java
@@ -17,14 +17,9 @@ public class BeanWalletService {
     private final BeanTransactionRepository beanTransactionRepository;
 
     public void rewardReferralBeans(User user, int amount){
-        // BeanWallet 조회,
         BeanWallet wallet = beanWalletRepository.findByUser(user).orElseGet(() -> createWalletForUser(user));
-
-        // 추천 원두 증가,
         wallet.increaseReferral(amount);
         beanWalletRepository.save(wallet);
-
-        // BeanTransaction 저장 (type REFERRAL_REWARD)
         beanTransactionRepository.save(
                 BeanTransaction.builder()
                         .user(user)

--- a/src/main/java/com/keodam/keodam_backend/mypage/payment/service/BeanWalletService.java
+++ b/src/main/java/com/keodam/keodam_backend/mypage/payment/service/BeanWalletService.java
@@ -1,0 +1,26 @@
+package com.keodam.keodam_backend.mypage.payment.service;
+
+import com.keodam.keodam_backend.app.domain.User;
+import com.keodam.keodam_backend.mypage.payment.domain.BeanWallet;
+import com.keodam.keodam_backend.mypage.payment.repository.BeanTransactionRepository;
+import com.keodam.keodam_backend.mypage.payment.repository.BeanWalletRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BeanWalletService {
+
+    private final BeanWalletRepository beanWalletRepository;
+    private final BeanTransactionRepository beanTransactionRepository;
+
+    public void rewardReferralBeans(User user, int amount){
+        // BeanWallet 조회, 추천 원두 증가, BeanTransaction 저장 (type REFERRAL_REWARD)
+    }
+
+    private BeanWallet createWalletForUser(User user){
+        return beanWalletRepository.save(
+                BeanWallet.builder().user(user).totalBeans(0).build()
+        );
+    }
+}

--- a/src/main/java/com/keodam/keodam_backend/mypage/payment/service/BeanWalletService.java
+++ b/src/main/java/com/keodam/keodam_backend/mypage/payment/service/BeanWalletService.java
@@ -6,6 +6,7 @@ import com.keodam.keodam_backend.mypage.payment.domain.BeanTransactionType;
 import com.keodam.keodam_backend.mypage.payment.domain.BeanWallet;
 import com.keodam.keodam_backend.mypage.payment.repository.BeanTransactionRepository;
 import com.keodam.keodam_backend.mypage.payment.repository.BeanWalletRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -16,6 +17,7 @@ public class BeanWalletService {
     private final BeanWalletRepository beanWalletRepository;
     private final BeanTransactionRepository beanTransactionRepository;
 
+    @Transactional
     public void rewardReferralBeans(User user, int amount){
         BeanWallet wallet = beanWalletRepository.findByUser(user).orElseGet(() -> createWalletForUser(user));
         wallet.increaseReferral(amount);

--- a/src/main/java/com/keodam/keodam_backend/mypage/payment/service/BeanWalletService.java
+++ b/src/main/java/com/keodam/keodam_backend/mypage/payment/service/BeanWalletService.java
@@ -1,6 +1,8 @@
 package com.keodam.keodam_backend.mypage.payment.service;
 
 import com.keodam.keodam_backend.app.domain.User;
+import com.keodam.keodam_backend.mypage.payment.domain.BeanTransaction;
+import com.keodam.keodam_backend.mypage.payment.domain.BeanTransactionType;
 import com.keodam.keodam_backend.mypage.payment.domain.BeanWallet;
 import com.keodam.keodam_backend.mypage.payment.repository.BeanTransactionRepository;
 import com.keodam.keodam_backend.mypage.payment.repository.BeanWalletRepository;
@@ -15,7 +17,22 @@ public class BeanWalletService {
     private final BeanTransactionRepository beanTransactionRepository;
 
     public void rewardReferralBeans(User user, int amount){
-        // BeanWallet 조회, 추천 원두 증가, BeanTransaction 저장 (type REFERRAL_REWARD)
+        // BeanWallet 조회,
+        BeanWallet wallet = beanWalletRepository.findByUser(user).orElseGet(() -> createWalletForUser(user));
+
+        // 추천 원두 증가,
+        wallet.increaseReferral(amount);
+        beanWalletRepository.save(wallet);
+
+        // BeanTransaction 저장 (type REFERRAL_REWARD)
+        beanTransactionRepository.save(
+                BeanTransaction.builder()
+                        .user(user)
+                        .wallet(wallet)
+                        .beanAmount(amount)
+                        .type(BeanTransactionType.REFERRAL_REWARD)
+                .build()
+        );
     }
 
     private BeanWallet createWalletForUser(User user){

--- a/src/main/java/com/keodam/keodam_backend/mypage/payment/service/PaymentService.java
+++ b/src/main/java/com/keodam/keodam_backend/mypage/payment/service/PaymentService.java
@@ -12,9 +12,9 @@ import com.keodam.keodam_backend.mypage.payment.domain.Payment;
 import com.keodam.keodam_backend.mypage.payment.dto.request.PaymentRequestDto;
 import com.keodam.keodam_backend.mypage.payment.dto.response.BootpayConfirmResponse;
 import com.keodam.keodam_backend.mypage.payment.dto.response.PaymentResponseDto;
+import com.keodam.keodam_backend.mypage.payment.repository.BeanTransactionRepository;
+import com.keodam.keodam_backend.mypage.payment.repository.BeanWalletRepository;
 import com.keodam.keodam_backend.mypage.payment.repository.PaymentRepository;
-import com.keodam.keodam_backend.mypage.payment.repository.beanTransactionRepository;
-import com.keodam.keodam_backend.mypage.payment.repository.beanWalletRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -25,8 +25,8 @@ public class PaymentService {
     private final BootpayService bootpayService;
     private final PaymentRepository paymentRepository;
     private final UserRepository userRepository;
-    private final beanWalletRepository beanWalletRepository;
-    private final beanTransactionRepository beanTransactionRepository;
+    private final BeanWalletRepository beanWalletRepository;
+    private final BeanTransactionRepository beanTransactionRepository;
 
     public PaymentResponseDto verifyAndSavePayment(PaymentRequestDto paymentRequestDto) {
 


### PR DESCRIPTION
추천인 등록 및 보상 API 구현
- 중복 등록 방지 (추천인 등록기능 기사용시 재등록 불가)
- 자기 자신 추천 방지 (예외처리)
- 추천인 & 피추천인 보상 지급 => 지갑, 트랜젝션과 연계하여 반영완료
- auth 요구
