### PR TITLE
[Feat]  프로필 등록한 유저 정보 삭제하는 api 추가

### DIFF
--- a/src/main/java/com/keodam/keodam_backend/app/user/controller/UserController.java
+++ b/src/main/java/com/keodam/keodam_backend/app/user/controller/UserController.java
@@ -129,4 +129,15 @@ public class UserController {
         userService.createMentoringBean(user, mentoringBean);
         return ResponseEntity.ok(ApiResponse.onSuccess("Successfully created mentoring bean."));
     }
+
+    @DeleteMapping("/delete-user")
+    @Operation(summary = "커뮤니티 최초 프로필 작성한 유저 정보 삭제 API", description = "커뮤니티 최초 프로필 작성 유저 삭제 API", security = @SecurityRequirement(name = "Authorization"))
+    public ResponseEntity<ApiResponse<String>> deleteUser(Authentication authentication) {
+        String email = authentication.getName();
+        User user = userService.findByEmail(email)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+        userService.deleteUser(user);
+        return ResponseEntity.ok(ApiResponse.onSuccess("Successfully delete user"));
+    }
 }
+

--- a/src/main/java/com/keodam/keodam_backend/app/user/service/UserService.java
+++ b/src/main/java/com/keodam/keodam_backend/app/user/service/UserService.java
@@ -2,7 +2,9 @@ package com.keodam.keodam_backend.app.user.service;
 
 import com.keodam.keodam_backend.app.phone.domain.UserIdentityInfo;
 import com.keodam.keodam_backend.app.phone.repository.UserIdentityInfoRepository;
+import com.keodam.keodam_backend.app.user.coffeechatprofile.domain.Mentee;
 import com.keodam.keodam_backend.app.user.coffeechatprofile.domain.Mentor;
+import com.keodam.keodam_backend.app.user.coffeechatprofile.repository.MenteeRepository;
 import com.keodam.keodam_backend.app.user.coffeechatprofile.repository.MentorRepository;
 import com.keodam.keodam_backend.app.user.domain.RoleType;
 import com.keodam.keodam_backend.app.user.domain.StudentStatus;
@@ -32,6 +34,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final AwsS3Service awsS3Service;
     private final MentorRepository mentorRepository;
+    private final MenteeRepository menteeRepository;
     private final UserIdentityInfoRepository userIdentityInfoRepository;
     private final TermAgreementRepository termAgreementRepository;
     private final ReferralRepository referralRepository;
@@ -211,6 +214,23 @@ public class UserService {
                 .mentoringBeanAmount(mentoringBean)
                 .build();
         mentorRepository.save(mentor);
+    }
+
+    @Transactional
+    public void deleteUser(User user) {
+        if (user.getRoleType() == RoleType.MENTOR) {
+            Mentor mentor = mentorRepository.findByUser(user).orElseThrow(()
+                    -> new GeneralException(ErrorStatus.MENTOR_NOT_FOUND));
+            mentorRepository.delete(mentor);
+        }
+        if (user.getRoleType() == RoleType.MENTEE) {
+            Mentee mentee = menteeRepository.findByUser(user).orElseThrow(()
+                    -> new GeneralException(ErrorStatus.MENTEE_NOT_FOUND));
+            menteeRepository.delete(mentee);
+        }
+        referralRepository.findBySponsor(user).ifPresent(referralRepository::delete);
+
+        userRepository.delete(user);
     }
 
     private boolean isMentorProfileComplete(User user) {


### PR DESCRIPTION
프로필을 등록한 유저의 정보를 삭제할 수 있는 API를 추가했습니다.  
FE 요청사항에 따라 해당 기능을 구현하였습니다.

### 🛠 구현 내용
- 프로필 등록 유저 삭제 API 추가
- `User`, `Mentor`, `Mentee`, `Referral` 등 연관 엔티티 삭제 처리