### PR TITLE
[Refactor] 프로필 등록 유저의 정보 삭제 리펙토링

### DIFF
--- a/src/main/java/com/keodam/keodam_backend/app/phone/repository/UserIdentityInfoRepository.java
+++ b/src/main/java/com/keodam/keodam_backend/app/phone/repository/UserIdentityInfoRepository.java
@@ -21,4 +21,5 @@ public interface UserIdentityInfoRepository extends JpaRepository<UserIdentityIn
 
     // 사용자 이름(실명)으로 사용자 정보 조회
     Optional<UserIdentityInfo> findByUserRealName(String userRealName);
+    void deleteByUser(User user);
 }

--- a/src/main/java/com/keodam/keodam_backend/app/user/coffeechatprofile/repository/MenteeRepository.java
+++ b/src/main/java/com/keodam/keodam_backend/app/user/coffeechatprofile/repository/MenteeRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 
 public interface MenteeRepository extends JpaRepository<Mentee, Long> {
     Optional<Mentee> findByUser(User user);
+    void deleteByUser(User user);
 }

--- a/src/main/java/com/keodam/keodam_backend/app/user/coffeechatprofile/repository/MentorHashtagRepository.java
+++ b/src/main/java/com/keodam/keodam_backend/app/user/coffeechatprofile/repository/MentorHashtagRepository.java
@@ -3,6 +3,7 @@ package com.keodam.keodam_backend.app.user.coffeechatprofile.repository;
 import com.keodam.keodam_backend.app.user.coffeechatprofile.domain.Mentor;
 import com.keodam.keodam_backend.app.user.coffeechatprofile.domain.MentorHashtag;
 import com.keodam.keodam_backend.app.user.coffeechatprofile.domain.MentorHashtagType;
+import com.keodam.keodam_backend.app.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -10,4 +11,5 @@ import java.util.List;
 public interface MentorHashtagRepository extends JpaRepository<MentorHashtag, Long> {
     void deleteByMentorAndHashtagType(Mentor mentor, MentorHashtagType mentorHashtagType);
     List<MentorHashtag> findAllByMentorAndHashtagType(Mentor mentor, MentorHashtagType type);
+    void deleteByMentor(Mentor mentor);
 }

--- a/src/main/java/com/keodam/keodam_backend/app/user/coffeechatprofile/repository/MentorRepository.java
+++ b/src/main/java/com/keodam/keodam_backend/app/user/coffeechatprofile/repository/MentorRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 
 public interface MentorRepository extends JpaRepository<Mentor, Long> {
     Optional<Mentor> findByUser(User user);
+    void deleteByUser(User user);
 }

--- a/src/main/java/com/keodam/keodam_backend/app/user/coffeechatprofile/repository/MypageStatsRepository.java
+++ b/src/main/java/com/keodam/keodam_backend/app/user/coffeechatprofile/repository/MypageStatsRepository.java
@@ -7,4 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MypageStatsRepository extends JpaRepository<MypageStats, Long> {
     Optional<MypageStats> findByUser(User user);
+    void deleteByUser(User user);
 }

--- a/src/main/java/com/keodam/keodam_backend/app/user/service/UserService.java
+++ b/src/main/java/com/keodam/keodam_backend/app/user/service/UserService.java
@@ -4,8 +4,7 @@ import com.keodam.keodam_backend.app.phone.domain.UserIdentityInfo;
 import com.keodam.keodam_backend.app.phone.repository.UserIdentityInfoRepository;
 import com.keodam.keodam_backend.app.user.coffeechatprofile.domain.Mentee;
 import com.keodam.keodam_backend.app.user.coffeechatprofile.domain.Mentor;
-import com.keodam.keodam_backend.app.user.coffeechatprofile.repository.MenteeRepository;
-import com.keodam.keodam_backend.app.user.coffeechatprofile.repository.MentorRepository;
+import com.keodam.keodam_backend.app.user.coffeechatprofile.repository.*;
 import com.keodam.keodam_backend.app.user.domain.RoleType;
 import com.keodam.keodam_backend.app.user.domain.StudentStatus;
 import com.keodam.keodam_backend.app.user.domain.User;
@@ -13,9 +12,19 @@ import com.keodam.keodam_backend.app.user.dto.StudentStatusRequestDto;
 import com.keodam.keodam_backend.app.user.dto.UserMeResponseDto;
 import com.keodam.keodam_backend.app.user.repository.UserRepository;
 import com.keodam.keodam_backend.app.user.dto.UserResponseDto;
+import com.keodam.keodam_backend.community.domain.Community;
+import com.keodam.keodam_backend.community.repository.CommunityCommentRepository;
+import com.keodam.keodam_backend.community.repository.CommunityImageRepository;
+import com.keodam.keodam_backend.community.repository.CommunityRepository;
 import com.keodam.keodam_backend.exception.GeneralException;
 import com.keodam.keodam_backend.global.aws.AwsS3Service;
 import com.keodam.keodam_backend.global.code.status.ErrorStatus;
+import com.keodam.keodam_backend.mypage.certification.repository.UserVerificationRepository;
+import com.keodam.keodam_backend.mypage.payment.repository.BeanTransactionRepository;
+import com.keodam.keodam_backend.mypage.payment.repository.BeanWalletRepository;
+import com.keodam.keodam_backend.mypage.payment.repository.PaymentRepository;
+import com.keodam.keodam_backend.mypage.roulette.repository.ExchangeRequestRepository;
+import com.keodam.keodam_backend.mypage.roulette.repository.RouletteSpinLogRepository;
 import com.keodam.keodam_backend.term.domain.TermType;
 import com.keodam.keodam_backend.term.repository.TermAgreementRepository;
 import com.keodam.keodam_backend.app.user.referral.repository.ReferralRepository;
@@ -24,6 +33,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -38,7 +48,17 @@ public class UserService {
     private final UserIdentityInfoRepository userIdentityInfoRepository;
     private final TermAgreementRepository termAgreementRepository;
     private final ReferralRepository referralRepository;
-
+    private final RouletteSpinLogRepository rouletteSpinLogRepository;
+    private final PaymentRepository paymentRepository;
+    private final MypageStatsRepository mypageStatsRepository;
+    private final ExchangeRequestRepository exchangeRequestRepository;
+    private final CommunityCommentRepository communityCommentRepository;
+    private final CommunityRepository communityRepository;
+    private final CommunityImageRepository communityImageRepository;
+    private final BeanTransactionRepository beanTransactionRepository;
+    private final BeanWalletRepository beanWalletRepository;
+    private final MentorHashtagRepository mentorHashtagRepository;
+    private final MenteeHashtagRepository menteeHashtagRepository;
 
     @Transactional(readOnly = true)
     public UserMeResponseDto getUserInfoAndSignupStep(String email) {
@@ -218,19 +238,58 @@ public class UserService {
 
     @Transactional
     public void deleteUser(User user) {
-        if (user.getRoleType() == RoleType.MENTOR) {
-            Mentor mentor = mentorRepository.findByUser(user).orElseThrow(()
-                    -> new GeneralException(ErrorStatus.MENTOR_NOT_FOUND));
-            mentorRepository.delete(mentor);
-        }
-        if (user.getRoleType() == RoleType.MENTEE) {
-            Mentee mentee = menteeRepository.findByUser(user).orElseThrow(()
-                    -> new GeneralException(ErrorStatus.MENTEE_NOT_FOUND));
-            menteeRepository.delete(mentee);
-        }
-        referralRepository.findBySponsor(user).ifPresent(referralRepository::delete);
-
+        deleteMentorData(user);
+        deleteMenteeData(user);
+        deleteReferralData(user);
+        deleteUserRelatedData(user);
+        deleteCommunityData(user);
+        deleteBeanData(user);
         userRepository.delete(user);
+    }
+
+    private void deleteMentorData(User user) {
+        if (user.getRoleType() == RoleType.MENTOR) {
+            mentorRepository.findByUser(user).ifPresent(mentor -> {
+                mentorHashtagRepository.deleteByMentor(mentor);
+                mentorRepository.delete(mentor);
+            });
+        }
+    }
+
+    private void deleteMenteeData(User user) {
+        if (user.getRoleType() == RoleType.MENTEE) {
+            menteeRepository.findByUser(user).ifPresent(mentee -> {
+                menteeHashtagRepository.deleteByMentee(mentee);
+                menteeRepository.delete(mentee);
+            });
+        }
+    }
+
+    private void deleteReferralData(User user) {
+        referralRepository.findBySponsor(user).ifPresent(referralRepository::delete);
+    }
+
+    private void deleteUserRelatedData(User user) {
+        userIdentityInfoRepository.deleteByUser(user);
+        termAgreementRepository.deleteByUser(user);
+        rouletteSpinLogRepository.deleteByUser(user);
+        paymentRepository.deleteByUser(user);
+        mypageStatsRepository.deleteByUser(user);
+        exchangeRequestRepository.deleteByUser(user);
+    }
+
+    private void deleteCommunityData(User user) {
+        List<Community> communities = communityRepository.findAllByUser(user);
+        for (Community community : communities) {
+            communityCommentRepository.deleteByCommunity(community);
+            communityImageRepository.deleteByCommunityId(community.getId());
+            communityRepository.delete(community);
+        }
+    }
+
+    private void deleteBeanData(User user) {
+        beanTransactionRepository.deleteByUser(user);
+        beanWalletRepository.deleteByUser(user);
     }
 
     private boolean isMentorProfileComplete(User user) {

--- a/src/main/java/com/keodam/keodam_backend/community/repository/CommunityCommentRepository.java
+++ b/src/main/java/com/keodam/keodam_backend/community/repository/CommunityCommentRepository.java
@@ -1,9 +1,15 @@
 package com.keodam.keodam_backend.community.repository;
 
+import com.keodam.keodam_backend.app.user.domain.User;
+import com.keodam.keodam_backend.community.domain.Community;
 import com.keodam.keodam_backend.community.domain.CommunityComment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
+import java.util.Optional;
 
 public interface CommunityCommentRepository extends JpaRepository<CommunityComment, Long> {
     List<CommunityComment> findByCommunityIdAndParentIsNull(Long communityId);
+    Optional<CommunityComment> findByUser(User user);
+    void deleteByUser(User user);
+    void deleteByCommunity(Community community);
 }

--- a/src/main/java/com/keodam/keodam_backend/community/repository/CommunityImageRepository.java
+++ b/src/main/java/com/keodam/keodam_backend/community/repository/CommunityImageRepository.java
@@ -2,9 +2,16 @@ package com.keodam.keodam_backend.community.repository;
 
 import com.keodam.keodam_backend.community.domain.CommunityImage;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface CommunityImageRepository extends JpaRepository<CommunityImage, Long> {
     List<CommunityImage> findByCommunityId(Long communityId);
+
+    @Modifying
+    @Query("DELETE FROM CommunityImage ci WHERE ci.community.id = :communityId")
+    void deleteByCommunityId(@Param("communityId") Long communityId);
 }

--- a/src/main/java/com/keodam/keodam_backend/community/repository/CommunityRepository.java
+++ b/src/main/java/com/keodam/keodam_backend/community/repository/CommunityRepository.java
@@ -1,7 +1,12 @@
 package com.keodam.keodam_backend.community.repository;
 
+import com.keodam.keodam_backend.app.user.domain.User;
 import com.keodam.keodam_backend.community.domain.Community;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CommunityRepository extends JpaRepository<Community, Long> {
+    void deleteByUser(User user);
+    List<Community> findAllByUser(User user);
 }

--- a/src/main/java/com/keodam/keodam_backend/mypage/certification/repository/UserVerificationRepository.java
+++ b/src/main/java/com/keodam/keodam_backend/mypage/certification/repository/UserVerificationRepository.java
@@ -1,5 +1,6 @@
 package com.keodam.keodam_backend.mypage.certification.repository;
 
+import com.keodam.keodam_backend.app.user.domain.User;
 import com.keodam.keodam_backend.mypage.certification.domain.UserVerification;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -7,4 +8,5 @@ import java.util.Optional;
 
 public interface UserVerificationRepository extends JpaRepository<UserVerification, Long> {
     Optional<UserVerification> findByUser_Email(String email);
+    Optional<UserVerification> findByUser(User user);
 }

--- a/src/main/java/com/keodam/keodam_backend/mypage/payment/repository/BeanTransactionRepository.java
+++ b/src/main/java/com/keodam/keodam_backend/mypage/payment/repository/BeanTransactionRepository.java
@@ -1,7 +1,9 @@
 package com.keodam.keodam_backend.mypage.payment.repository;
 
+import com.keodam.keodam_backend.app.user.domain.User;
 import com.keodam.keodam_backend.mypage.payment.domain.BeanTransaction;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BeanTransactionRepository extends JpaRepository<BeanTransaction, Long> {
+    void deleteByUser(User user);
 }

--- a/src/main/java/com/keodam/keodam_backend/mypage/payment/repository/BeanWalletRepository.java
+++ b/src/main/java/com/keodam/keodam_backend/mypage/payment/repository/BeanWalletRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface BeanWalletRepository extends JpaRepository<BeanWallet, Long> {
     Optional<BeanWallet> findByUser(User user);
+    void deleteByUser(User user);
 }

--- a/src/main/java/com/keodam/keodam_backend/mypage/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/keodam/keodam_backend/mypage/payment/repository/PaymentRepository.java
@@ -1,9 +1,11 @@
 package com.keodam.keodam_backend.mypage.payment.repository;
 
+import com.keodam.keodam_backend.app.user.domain.User;
 import com.keodam.keodam_backend.mypage.payment.domain.Payment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
 
     boolean existsByReceiptId(String receiptId);
+    void deleteByUser(User user);
 }

--- a/src/main/java/com/keodam/keodam_backend/mypage/roulette/repository/ExchangeRequestRepository.java
+++ b/src/main/java/com/keodam/keodam_backend/mypage/roulette/repository/ExchangeRequestRepository.java
@@ -1,7 +1,12 @@
 package com.keodam.keodam_backend.mypage.roulette.repository;
 
+import com.keodam.keodam_backend.app.user.domain.User;
 import com.keodam.keodam_backend.mypage.roulette.domain.ExchangeRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ExchangeRequestRepository extends JpaRepository<ExchangeRequest, Long> {
+    Optional<ExchangeRequest> findByUser(User user);
+    void deleteByUser(User user);
 }

--- a/src/main/java/com/keodam/keodam_backend/mypage/roulette/repository/RouletteSpinLogRepository.java
+++ b/src/main/java/com/keodam/keodam_backend/mypage/roulette/repository/RouletteSpinLogRepository.java
@@ -1,7 +1,11 @@
 package com.keodam.keodam_backend.mypage.roulette.repository;
 
+import com.keodam.keodam_backend.app.user.domain.User;
 import com.keodam.keodam_backend.mypage.roulette.domain.RouletteSpinLog;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface RouletteSpinLogRepository extends JpaRepository<RouletteSpinLog, Long> {
+    void deleteByUser(User user);
 }

--- a/src/main/java/com/keodam/keodam_backend/term/repository/TermAgreementRepository.java
+++ b/src/main/java/com/keodam/keodam_backend/term/repository/TermAgreementRepository.java
@@ -14,4 +14,6 @@ public interface TermAgreementRepository extends JpaRepository<TermAgreement, Te
     Optional<TermAgreement> findByUserAndTerm(User user, Term term);
 
     boolean existsByUserAndTerm_Type(User user, TermType type);
+
+    void deleteByUser(User user);
 }


### PR DESCRIPTION
프로필을 등록한 유저의 정보를 삭제할 수 있는 기능을 리팩토링했습니다.  

🛠 구현 내용
- deleteUser 메서드 리팩토링: 기존 연관 관계에서 더 추가해 
Mentor, Mentee, Referral, Community 등 연관 엔티티 삭제 로직을 별도 메서드로 분리
- 커뮤니티 댓글, 이미지, 멘토/멘티 해시태그 등 연관 데이터 삭제
